### PR TITLE
Update build rules to allow building for Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "build": "react-scripts build && electron-builder --win",
     "publish": "react-scripts build && electron-builder --win -p always",
     "build-portable": "react-scripts build && electron-builder --win portable",
+    "build-linux": "react-scripts build && electron-builder --linux",
+    "publish-linux": "react-scripts build && electron-builder --linux -p always",
     "start": "concurrently \"cross-env BROWSER=none react-scripts start\" \"wait-on http://localhost:3000 && electron .\""
   },
   "build": {
@@ -72,6 +74,10 @@
           "beatdrop"
         ]
       }
+    },
+    "linux": {
+      "target": "tar.gz",
+      "icon": "resources/icon.ico"
     }
   },
   "browserslist": [


### PR DESCRIPTION
For now just does linux, x64 as a portable tar.gz
- npm run build-linux
- npm run publish-linux

Produced archive can be used by extracting then running beatdrop
executable as expected

Beatdrop starts, and seems to function correctly for downloading files
Likely setup/initial patching for bsipa doesn't work