### PR TITLE
Fix for a folder creation bug

### DIFF
--- a/src/actions/queueActions.js
+++ b/src/actions/queueActions.js
@@ -94,7 +94,7 @@ export const downloadSong = (identity) => (dispatch, getState) => {
                 let extractTo
                 switch(getState().settings.folderStructure) {
                   case 'keySongNameArtistName':
-                    extractTo = `${ song.key } (${ song.metadata.songName.replace(/[\\/:*?"<>|.]/g, '') } - ${ song.metadata.songAuthorName })`
+                    extractTo = `${ song.key } (${ song.metadata.songName.replace(/[\\/:*?"<>|.]/g, '') } - ${ song.metadata.songAuthorName.replace(/[\\/:*?"<>|.]/g, '') })`
                     break
                   case 'key':
                     extractTo = song.key
@@ -103,7 +103,7 @@ export const downloadSong = (identity) => (dispatch, getState) => {
                     extractTo = song.name.replace(/[\\/:*?"<>|.]/g, '')
                     break
                   default:
-                    extractTo = `${ song.key } (${ song.name.replace(/[\\/:*?"<>|.]/g, '') } - ${ song.songAuthorName })`
+                    extractTo = `${ song.key } (${ song.name.replace(/[\\/:*?"<>|.]/g, '') } - ${ song.songAuthorName.replace(/[\\/:*?"<>|.]/g, '') })`
                     break
                 }
                 zip.extractAllTo(path.join(getState().settings.installationDirectory, 'Beat Saber_Data', 'CustomLevels', extractTo))


### PR DESCRIPTION
This PR submits a small fix for a bug where if a song author name contained illegal characters (slashes etc.) they would not be removed, resulting in a corrupted folder structure.

For example, [this map](https://beatsaver.com/api/maps/detail/48) (beat saver key `48`) would create a folder `48 (HERO! - Murata` with a subfolder `ONE )`, in which the song data will reside. This will result in the level being inaccessible (and not displayed) within Beat Saber.

Below is the excerpt from the details json for the song:
```
songName: "HERO!",
songSubName: "Beatmap by WitchWhoCleans",
songAuthorName: "Murata/ ONE", // <-- forward slashes in this value result in creating unnecessary subfolders
levelAuthorName: "witchwhocleans",
bpm: 130
```

The expected behavior after the fix is for the illegal characters to be removed from the `songAuthorName` as well.